### PR TITLE
feat: Add support for Sepolia and Holesky Ethereum testnets

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -29,6 +29,8 @@ enum ChainRef {
     CHAIN_GOERLI = 10005;
     CHAIN_ROPSTEN = 10006;
     CHAIN_RINKEBY = 10007;
+    CHAIN_HOLESKY = 10008;
+    CHAIN_SEPOLIA = 10009;
 
     // Non-standard starts from 20_000
 }


### PR DESCRIPTION
- Add `CHAIN_HOLESKY` and `CHAIN_SEPOLIA` to `ChainRef` enum.

These are the contemporary public Ethereum testnets.

https://sepolia.dev/

https://github.com/eth-clients/holesky